### PR TITLE
Fixed #21

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Version 2.2.3
+
+- Fix [#21](https://github.com/kf99916/TimelineTableViewCell/issues/21).
+
 ## Versiion 2.2.2
 
 - Fix [#19](https://github.com/kf99916/TimelineTableViewCell/issues/19).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Version 2.2.3
 
 - Fix [#21](https://github.com/kf99916/TimelineTableViewCell/issues/21).
+- Minimum iOS version is now 12
 
 ## Versiion 2.2.2
 

--- a/Package.swift
+++ b/Package.swift
@@ -1,11 +1,11 @@
-// swift-tools-version:5.1
+// swift-tools-version:5.9
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription
 
 let package = Package(
     name: "TimelineTableViewCell",
-    platforms: [.iOS(.v9)],
+    platforms: [.iOS(.v12)],
     products: [
         // Products define the executables and libraries produced by a package, and make them visible to other packages.
         .library(
@@ -22,7 +22,11 @@ let package = Package(
         .target(
             name: "TimelineTableViewCell",
             dependencies: [],
-            path: "TimelineTableViewCell"),
+            path: "TimelineTableViewCell",
+            resources: [
+                .process("TimelineTableViewCell.xib")
+            ]
+            ),
     ],
     swiftLanguageVersions: [.v5]
 )

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ TimelineTableViewCell is a simple timeline view implemented by UITableViewCell. 
 
 ## Requirements
 
-- iOS 9.0 or higher
+- iOS 12.0 or higher
 
 ### v1.0.1-
 

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ let timelineTableViewCellNib = UINib(nibName: "TimelineTableViewCell", bundle: n
 controller.tableView.register(timelineTableViewCellNib, forCellReuseIdentifier: "TimelineTableViewCell")
 ```
 
-Before 2.2.3 with CocoaPods:
+with CocoaPods:
 ```swift
 let bundle = Bundle(for: TimelineTableViewCell.self)
 let nibUrl = bundle.url(forResource: "TimelineTableViewCell", withExtension: "bundle")

--- a/README.md
+++ b/README.md
@@ -66,6 +66,16 @@ import TimelineTableViewCell
 
 #### Register Nib
 
+After 2.2.3 with SPM:
+```swift
+let bundle = Bundle(for: TimelineTableViewCell.self)
+guard let nibUrl = bundle.url(forResource: "TimelineTableViewCell_TimelineTableViewCell", withExtension: "bundle"),
+      let nibBundle = Bundle(url: nibUrl) else { return } // guard is optional
+let timelineTableViewCellNib = UINib(nibName: "TimelineTableViewCell", bundle: nibBundle)
+controller.tableView.register(timelineTableViewCellNib, forCellReuseIdentifier: "TimelineTableViewCell")
+```
+
+Before 2.2.3 with CocoaPods:
 ```swift
 let bundle = Bundle(for: TimelineTableViewCell.self)
 let nibUrl = bundle.url(forResource: "TimelineTableViewCell", withExtension: "bundle")

--- a/TimelineTableViewCell.podspec
+++ b/TimelineTableViewCell.podspec
@@ -8,8 +8,9 @@
 
 Pod::Spec.new do |s|
   s.name             = 'TimelineTableViewCell'
-  s.version          = '2.2.2'
+  s.version          = '2.2.3'
   s.summary          = 'Simple timeline view implemented by UITableViewCell'
+  s.swift_versions   = ['5.0']
 
 # This description is used to generate tags and improve search results.
 #   * Think: What does it do? Why did you write it? What is the focus?
@@ -26,7 +27,7 @@ Pod::Spec.new do |s|
   s.source           = { :git => 'https://github.com/kf99916/TimelineTableViewCell.git', :tag => s.version.to_s }
   # s.social_media_url = 'https://twitter.com/<TWITTER_USERNAME>'
 
-  s.ios.deployment_target = '9.0'
+  s.ios.deployment_target = '12.0'
 
   s.source_files = 'TimelineTableViewCell/**/*.swift'
   

--- a/TimelineTableViewCell/TimelineTableViewCell.xib
+++ b/TimelineTableViewCell/TimelineTableViewCell.xib
@@ -11,7 +11,7 @@
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
-        <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" id="mx5-YM-BCr" customClass="TimelineTableViewCell" customModule="TimelineTableViewCell" customModuleProvider="target">
+        <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" id="mx5-YM-BCr" customClass="TimelineTableViewCell" customModule="TimelineTableViewCell">
             <rect key="frame" x="0.0" y="0.0" width="375" height="88"/>
             <autoresizingMask key="autoresizingMask"/>
             <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="mx5-YM-BCr" id="HxZ-h8-hOq">


### PR DESCRIPTION
- fixed Package.swift to work with newer SPM and correctly copy xib
- fixed TimelineTableViewCell.xib to work with SPM (removed customModuleProvider="target") to correctly resolve it while imported with SPM
- fixed issue that pod lint used Swift 4 as default and errors out (added s.swift_versions = ['5.0'])
- updated CHANGELOG.md with changes and README.md to reflect how nib registration works with SPM
- upped deployment target to iOS 12, as required for new swift-tools to correctly process xib

checked that CocoaPods install works as before (copy-pasted nib registration code from this repo README.md and created example table) so no breaking changes except deployment target, hopefully